### PR TITLE
Fixed performance bug in the coaxial model

### DIFF
--- a/model-current/.gitignore
+++ b/model-current/.gitignore
@@ -1,3 +1,5 @@
 Manifest.toml
 ./results/*
 ./array_results/*
+./results_gpu/*
+*.vti

--- a/model-current/dbhe-coaxial.jl
+++ b/model-current/dbhe-coaxial.jl
@@ -1,3 +1,5 @@
+using Pkg
+Pkg.activate(@__DIR__)
 using LinearAlgebra
 using .Threads
 using WriteVTK
@@ -15,7 +17,7 @@ include("utils.jl")
 #
 
 # Create experiment folder #####################################################
-path = "results/"
+path = joinpath(@__DIR__, "results/")
 rm(path, recursive=true, force=true)
 mkpath(path)
 
@@ -143,7 +145,7 @@ for k in 1:kk
         yj = j*dy
         for i in 1:ii
             xi = i*dx
-            r = norm([xi,yj]-[xc,yc])
+            r = sqrt((xi - xc)^2 + (yj - yc)^2)
             if r < r1  # inside inner pipe
                 d[i,j,k] = df
                 vx[i,j,k] = 0
@@ -189,13 +191,13 @@ save(path,"diff_coeff",d,rx,ry,rz,0)
 # Simulation ##################################################################
 
 # Solve eq. system
-function updateϕ_domain!(ϕ2,ϕ1,d,vx,vy,vz,dx,dy,dz,dt,xc,yc,r1,t1,r2)
+function updateϕ_domain!(ϕ2,ϕ1,d,vx,vy,vz,dx,dy,dz,dt,xc,yc,r1,t1,r2,ε,kk,ii,jj)
     @threads for k = 2:kk-1
         for j = 2:jj-1
             for i = 2:ii-1                
                 # Convective term
                 xi, yj = i*dx, j*dy
-                r = norm([xi,yj]-[xc,yc])
+                r = sqrt((xi - xc)^2 + (yj - yc)^2)
                 if r < r1  # inside inner pipe 
                     conv = ( ε*vx[i,j,k]*(ϕ1[i+1,j,k]-ϕ1[i,j,k])/dx
                             +ε*vy[i,j,k]*(ϕ1[i,j+1,k]-ϕ1[i,j,k])/dy
@@ -233,13 +235,13 @@ function updateϕ_boundaries!(ϕ,ii,jj,kk,dx,dy,dz)
 end
 
 # Run simulation
-@time for t = 0:2:tt
+for t = 0:2:tt
     # Update ϕ
-    updateϕ_domain!(ϕ2,ϕ1,d,vx,vy,vz,dx,dy,dz,dt,xc,yc,r1,t1,r2)
+    updateϕ_domain!(ϕ2,ϕ1,d,vx,vy,vz,dx,dy,dz,dt,xc,yc,r1,t1,r2,ε,kk,ii,jj)
     updateϕ_boundaries!(ϕ2,ii,jj,kk,dx,dy,dz)
     
     # Update ϕ
-    updateϕ_domain!(ϕ1,ϕ2,d,vx,vy,vz,dx,dy,dz,dt,xc,yc,r1,t1,r2)
+    updateϕ_domain!(ϕ1,ϕ2,d,vx,vy,vz,dx,dy,dz,dt,xc,yc,r1,t1,r2,ε,kk,ii,jj)
     updateϕ_boundaries!(ϕ1,ii,jj,kk,dx,dy,dz)
     
     # Save ϕ
@@ -248,6 +250,3 @@ end
         save(path,"temperature",ϕ2,rx,ry,rz,t)
     end
 end
-
-# for 24simulation time and using salloc --mem=32G -t 2:00:00 --gres=gpu:h100:1
-# 3209.602894 seconds (166.23 G allocations: 2.688 TiB, 7.91% gc time, 0.01% compilation time)

--- a/model-current/dbhe-coaxial.jl
+++ b/model-current/dbhe-coaxial.jl
@@ -233,7 +233,7 @@ function updateϕ_boundaries!(ϕ,ii,jj,kk,dx,dy,dz)
 end
 
 # Run simulation
-for t = 0:2:tt
+@time for t = 0:2:tt
     # Update ϕ
     updateϕ_domain!(ϕ2,ϕ1,d,vx,vy,vz,dx,dy,dz,dt,xc,yc,r1,t1,r2)
     updateϕ_boundaries!(ϕ2,ii,jj,kk,dx,dy,dz)
@@ -249,3 +249,4 @@ for t = 0:2:tt
     end
 end
 
+# 3209.602894 seconds (166.23 G allocations: 2.688 TiB, 7.91% gc time, 0.01% compilation time)

--- a/model-current/dbhe-coaxial.jl
+++ b/model-current/dbhe-coaxial.jl
@@ -249,4 +249,5 @@ end
     end
 end
 
+# for 24simulation time and using salloc --mem=32G -t 2:00:00 --gres=gpu:h100:1
 # 3209.602894 seconds (166.23 G allocations: 2.688 TiB, 7.91% gc time, 0.01% compilation time)


### PR DESCRIPTION
This is now ~2 orders of magnitude faster.
Another ~2 orders on top of that can be gained by using GPUs. See branch: https://github.com/cwittens/GEO/tree/using_kernels/model-current/gpu_model
This however is not ready for a PR yet.
 